### PR TITLE
Change urllib2 to urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-urllib2
+urllib3
 pyminizip


### PR DESCRIPTION
Changing urllib2 to urllib3 fixes pip requirements installation errors