### PR TITLE
Remove broken pyminizip dependency

### DIFF
--- a/prep_file.py
+++ b/prep_file.py
@@ -55,7 +55,6 @@ def prepare_file(file_path):
 
     # create ZIP Archive
     # we are using 7z because "zipfile" did not support adding a password
-    # Apparently "pyminizip" works just as well.
     print('Info: Creating encrypted ZIP archive')
     with pyzipper.AESZipFile(OUTPUT_FOLDER / f'{file_path.name}.zip', 'w', compression=pyzipper.ZIP_LZMA, encryption=pyzipper.WZ_AES) as zip_file:
         zip_file.setpassword(COMPRESSION_PASSWORD.encode())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 urllib3
-pyminizip
 pyzipper

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     urllib3
-    pyminizip
     pyzipper
 
 [options.entry_points]


### PR DESCRIPTION
Summary: remove pyminizip from requirements and setup.cfg, keep pyzipper as the ZIP implementation in prep_file.py, and fix the install failure on current macOS/Python 3.14 builds. The project already uses pyzipper for archive creation, so this change only removes the unused dependency that no longer builds cleanly.